### PR TITLE
OpenAI 설정 개선 및 GPT 요청 구조 리팩토링

### DIFF
--- a/src/main/java/com/finalproject/backend/config/OpenAiConfig.java
+++ b/src/main/java/com/finalproject/backend/config/OpenAiConfig.java
@@ -1,8 +1,22 @@
 package com.finalproject.backend.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.theokanning.openai.OpenAiApi;
 import com.theokanning.openai.service.OpenAiService;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+import java.util.concurrent.TimeUnit;
+
+import java.io.IOException;
 
 @Configuration
 public class OpenAiConfig {
@@ -13,7 +27,39 @@ public class OpenAiConfig {
         if (apiKey == null || apiKey.isBlank()) {
             throw new IllegalStateException("환경변수 OPENAI_API_KEY가 설정되지 않았습니다.");
         }
-        return new OpenAiService(apiKey);
-    }
 
+        String organizationId = "org-bpMyrbQBlPxrZA7pZrGtYEvk"; // 실제 조직 ID
+
+        OkHttpClient client = new OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(120, TimeUnit.SECONDS)     // 🔥 중요: GPT 응답 시간 대비
+                .writeTimeout(30, TimeUnit.SECONDS)
+                .addInterceptor(new Interceptor() {
+                    @Override
+                    public Response intercept(Chain chain) throws IOException {
+                        Request original = chain.request();
+                        Request request = original.newBuilder()
+                                .header("Authorization", "Bearer " + apiKey)
+                                .header("OpenAI-Organization", organizationId)
+                                .method(original.method(), original.body())
+                                .build();
+                        return chain.proceed(request);
+                    }
+                })
+                .build();
+
+        // ✅ 핵심: Jackson 설정에서 unknown property 무시 설정
+        ObjectMapper objectMapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl("https://api.openai.com/")
+                .client(client)
+                .addConverterFactory(JacksonConverterFactory.create(objectMapper)) // ← 여기!
+                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+                .build();
+
+        OpenAiApi api = retrofit.create(OpenAiApi.class);
+        return new OpenAiService(api);
+    }
 }

--- a/src/main/java/com/finalproject/backend/dto/GTP/SafeChatMessage.java
+++ b/src/main/java/com/finalproject/backend/dto/GTP/SafeChatMessage.java
@@ -1,0 +1,11 @@
+package com.finalproject.backend.dto.GTP;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.theokanning.openai.completion.chat.ChatMessage;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SafeChatMessage extends ChatMessage {
+    public SafeChatMessage(String role, String content) {
+        super(role, content);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+openai:
+  api:
+    key: ${OPENAI_API_KEY}
+
+spring:
+  jackson:
+    deserialization:
+      fail-on-unknown-properties: false


### PR DESCRIPTION
## OpenAI 설정 개선

1. OpenAI 설정 개선
- API 키와 함께 조직 ID를 헤더에 포함하도록 설정
- OkHtitpClient와 Retrofit 구성으로 타임아웃 및 Jackson 설정 커스터마이징
2. GPT요청 구조 리팩토링
- 프롬프트 (REVIEW_PROMPT, REFACTOR_PROMPT)를 분리
- 사용자 메시지 생성 시 SafeChatMessage를 도입해 직렬화 예외 방지
- diff 문자열의 이스케이프 문자를 복원하는 유틸 함수 decodeEscapedDiff() 추가
3. 설정 파일 변경
- application.yml에 OpenAI API키 및 Jackson unknown-property 무시 설정 추가
